### PR TITLE
Dev/register node

### DIFF
--- a/src/main/java/com/vmware/bespin/rpc/RPCServer.java
+++ b/src/main/java/com/vmware/bespin/rpc/RPCServer.java
@@ -5,16 +5,17 @@
 
 package com.vmware.bespin.rpc;
 
+import com.vmware.bespin.scheduler.rpc.RPCID;
+
 import java.io.IOException;
 
 /// RPC server operations
 public abstract class RPCServer {
     /// Register an RPC func with an ID
-    // TODO: should probably alias type for rpcId
-    public abstract boolean register(byte rpcId, RPCHandler handler);
+    public abstract boolean register(RPCID id, RPCHandler handler);
 
     ///  Accept an RPC client
-    // TODO: should really have a handler as an argument but oh well
+    // TODO: should really have a handler as an argument but not needed yet
     public abstract boolean addClient();
 
     /// Run the RPC server

--- a/src/main/java/com/vmware/bespin/rpc/TCPServer.java
+++ b/src/main/java/com/vmware/bespin/rpc/TCPServer.java
@@ -5,6 +5,7 @@
 
 package com.vmware.bespin.rpc;
 
+import com.vmware.bespin.scheduler.rpc.RPCID;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -45,13 +46,13 @@ public class TCPServer extends RPCServer {
     }
 
     @Override
-    public boolean register(final byte rpcId, final RPCHandler handler) {
+    public boolean register(final RPCID rpcId, final RPCHandler handler) {
         // Cannot add if key already exists
-        if (this.handlers.containsKey(rpcId)) {
+        if (this.handlers.containsKey(rpcId.id())) {
             return false;
         }
 
-        this.handlers.put(rpcId, handler);
+        this.handlers.put(rpcId.id(), handler);
         return true;
     }
 

--- a/src/main/java/com/vmware/bespin/scheduler/Constraints.java
+++ b/src/main/java/com/vmware/bespin/scheduler/Constraints.java
@@ -66,7 +66,7 @@ public class Constraints {
                     select * from pending
                     join unallocated
                         on unallocated.node = pending.controllable__node
-                    check capacity_constraint(pending.controllable__node, unallocated.node, pending.memslices, 
+                    check capacity_constraint(pending.controllable__node, unallocated.node, pending.memslices,
                         unallocated.memslices) = true
                 """);
     }

--- a/src/main/java/com/vmware/bespin/scheduler/Scheduler.java
+++ b/src/main/java/com/vmware/bespin/scheduler/Scheduler.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2022 VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: BSD-2 OR MIT
+ */
+
+package com.vmware.bespin.scheduler;
+
+import com.vmware.bespin.rpc.RPCServer;
+import com.vmware.bespin.rpc.TCPServer;
+
+import com.vmware.bespin.scheduler.rpc.RPCID;
+import com.vmware.bespin.scheduler.rpc.RegisterNodeHandler;
+import com.vmware.bespin.scheduler.rpc.SchedulerHandler;
+import com.vmware.dcm.Model;
+import com.vmware.dcm.ModelException;
+import com.vmware.dcm.SolverException;
+
+import com.vmware.bespin.scheduler.generated.tables.Applications;
+import com.vmware.bespin.scheduler.generated.tables.Pending;
+import com.vmware.bespin.scheduler.generated.tables.Placed;
+import com.vmware.bespin.scheduler.generated.tables.Nodes;
+
+import org.jooq.DSLContext;
+import org.jooq.Record;
+import org.jooq.Result;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.SocketException;
+
+public class Scheduler {
+    private final Model model;
+    private final DSLContext conn;
+    private final int maxReqsPerSolve;
+    private final long maxTimePerSolve;
+    private final long pollInterval;
+    private final DatagramSocket udpSocket;
+    private final InetAddress ip;
+    private final int port;
+    private static final Logger LOG = LogManager.getLogger(Scheduler.class);
+
+    public static final Applications APPLICATION_TABLE = Applications.APPLICATIONS;
+    public static final Pending PENDING_TABLE = Pending.PENDING;
+    public static final Placed PLACED_TABLE = Placed.PLACED;
+    public static final Nodes NODE_TABLE = Nodes.NODES;
+
+    Scheduler(final Model model, final DSLContext conn, final int maxReqsPerSolve, final long maxTimePerSolve,
+              final long pollInterval, final InetAddress ip, final int port) throws SocketException {
+        this.model = model;
+        this.conn = conn;
+        this.maxReqsPerSolve = maxReqsPerSolve;
+        this.maxTimePerSolve = maxTimePerSolve;
+        this.pollInterval = pollInterval;
+        this.udpSocket = new DatagramSocket();
+        this.ip = ip;
+        this.port = port;
+    }
+
+    public boolean runModelAndUpdateDB() throws IOException, NullPointerException {
+        final Result<? extends Record> results;
+        try {
+            results = model.solve("PENDING");
+        } catch (ModelException | SolverException e) {
+            LOG.error(e);
+            return false;
+        }
+
+        // TODO: should find a way to batch these, both to/from database but also in communication with controller
+        // Add new assignments to placed, remove new assignments from pending, notify listener of changes
+        for (final Record record : results) {
+            // Extract fields from the record
+            final Long recordId = (Long) record.get("ID");
+            final Integer controllableNode = (Integer) record.get("CONTROLLABLE__NODE");
+            final Integer cores = (Integer) record.get("CORES");
+            final Integer memslices = (Integer) record.get("MEMSLICES");
+            if (controllableNode == null) {
+                throw new NullPointerException();
+            }
+
+            // Add to placed table
+            conn.insertInto(PLACED_TABLE, PLACED_TABLE.APPLICATION, PLACED_TABLE.NODE, PLACED_TABLE.CORES,
+                            PLACED_TABLE.MEMSLICES)
+                    .values((Integer) record.get("APPLICATION"), controllableNode, cores, memslices)
+                    .onDuplicateKeyUpdate()
+                    .set(PLACED_TABLE.CORES,  PLACED_TABLE.CORES.plus(cores))
+                    .set(PLACED_TABLE.MEMSLICES, PLACED_TABLE.MEMSLICES.plus(memslices))
+                    .execute();
+            // Delete from pending table
+            conn.deleteFrom(PENDING_TABLE)
+                    .where(PENDING_TABLE.ID.eq(recordId))
+                    .execute();
+
+            // TODO: move object creation out of loop
+            final SchedulerAssignment assignment = new SchedulerAssignment(recordId, controllableNode.longValue());
+            final DatagramPacket packet = new DatagramPacket(assignment.toBytes(), SchedulerAssignment.BYTE_LEN);
+            packet.setAddress(this.ip);
+            packet.setPort(this.port);
+            this.udpSocket.send(packet);
+            LOG.info("Sent allocation for {}", (Long) record.get("ID"));
+            this.udpSocket.receive(packet);
+        }
+        return true;
+    }
+
+    private int getNumPendingRequests() {
+        final String numRequests = "select count(1) from pending";
+        return ((Long) this.conn.fetch(numRequests).get(0).getValue(0)).intValue();
+    }
+
+    public void run() throws InterruptedException, IOException {
+
+        final Runnable rpcRunner =
+                () -> {
+                    try {
+                        LOG.info("RPCServer thread started");
+                        final RPCServer rpcServer = new TCPServer("172.31.0.20", 6970);
+                        LOG.info("Created server");
+                        rpcServer.register(RPCID.REGISTER_NODE, new RegisterNodeHandler(conn));
+                        rpcServer.register(RPCID.SCHEDULER, new SchedulerHandler(conn));
+                        LOG.info("Registered handlers");
+                        rpcServer.addClient();
+                        LOG.info("Added Client");
+                        rpcServer.runServer();
+                    } catch (final IOException e) {
+                        LOG.error("RPCServer thread failed");
+                        LOG.error(e);
+                        throw new RuntimeException();
+                    }
+                };
+        final Thread thread = new Thread(rpcRunner);
+        thread.start();
+
+        // Enter loop solve loop
+        long lastSolve = System.currentTimeMillis();
+        while (true) {
+            // Sleep for poll interval
+            Thread.sleep(this.pollInterval);
+
+            // Get time elapsed since last solve
+            final long timeElapsed = System.currentTimeMillis() - lastSolve;
+
+            // Get number of rows
+            final int numRequests = this.getNumPendingRequests();
+
+            // If time since last solve is too long, solve
+            if (timeElapsed >= this.maxTimePerSolve || numRequests >= this.maxReqsPerSolve) {
+                if (numRequests > 0) {
+                    if (timeElapsed >= this.maxTimePerSolve) {
+                        LOG.info(String.format("solver thread solving due to timeout: numRequests = %d", numRequests));
+                    } else {
+                        LOG.info(String.format("solver thread solving due to numRequests = %d", numRequests));
+                    }
+                    // Only actually solve if work to do, exit if solver error
+                    if (!this.runModelAndUpdateDB()) {
+                        break;
+                    }
+                }
+                lastSolve = System.currentTimeMillis();
+            }
+        } // while (true)
+    }
+}

--- a/src/main/java/com/vmware/bespin/scheduler/Scheduler.java
+++ b/src/main/java/com/vmware/bespin/scheduler/Scheduler.java
@@ -61,7 +61,7 @@ public class Scheduler {
         this.port = port;
     }
 
-    public boolean runModelAndUpdateDB() throws IOException, NullPointerException {
+    public boolean runModelAndUpdateDB() throws IOException {
         final Result<? extends Record> results;
         try {
             results = model.solve("PENDING");
@@ -78,9 +78,6 @@ public class Scheduler {
             final Integer controllableNode = (Integer) record.get("CONTROLLABLE__NODE");
             final Integer cores = (Integer) record.get("CORES");
             final Integer memslices = (Integer) record.get("MEMSLICES");
-            if (controllableNode == null) {
-                throw new NullPointerException();
-            }
 
             // Add to placed table
             conn.insertInto(PLACED_TABLE, PLACED_TABLE.APPLICATION, PLACED_TABLE.NODE, PLACED_TABLE.CORES,

--- a/src/main/java/com/vmware/bespin/scheduler/SchedulerRunner.java
+++ b/src/main/java/com/vmware/bespin/scheduler/SchedulerRunner.java
@@ -5,31 +5,15 @@
 
 package com.vmware.bespin.scheduler;
 
-import com.vmware.bespin.rpc.RPCHandler;
-import com.vmware.bespin.rpc.RPCHeader;
-import com.vmware.bespin.rpc.RPCMessage;
-import com.vmware.bespin.rpc.RPCServer;
-import com.vmware.bespin.rpc.TCPServer;
-
 import com.vmware.dcm.Model;
-import com.vmware.dcm.ModelException;
-import com.vmware.dcm.SolverException;
-
-import com.vmware.bespin.scheduler.generated.tables.Pending;
-import com.vmware.bespin.scheduler.generated.tables.Placed;
 
 import org.jooq.DSLContext;
-import org.jooq.Field;
-import org.jooq.Record;
-import org.jooq.Result;
 import org.jooq.impl.DSL;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 
-import java.net.DatagramPacket;
-import java.net.DatagramSocket;
 import java.net.InetAddress;
 import java.net.SocketException;
 import java.net.UnknownHostException;
@@ -42,174 +26,9 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 
-class Scheduler {
-    private final Model model;
-    private final DSLContext conn;
-    private final int maxReqsPerSolve;
-    private final long maxTimePerSolve;
-    private final long pollInterval;
-    private final DatagramSocket udpSocket;
-    private final InetAddress ip;
-    private final int port;
-    int requestsReceived = 0;
-    int allocationsSent = 0;
-    private static final Logger LOG = LogManager.getLogger(Scheduler.class);
-
-    static final Pending PENDING_TABLE = Pending.PENDING;
-    static final Placed PLACED_TABLE = Placed.PLACED;
-
-    Scheduler(final Model model, final DSLContext conn, final int maxReqsPerSolve, final long maxTimePerSolve, 
-            final long pollInterval, final InetAddress ip, final int port) throws SocketException {
-        this.model = model;
-        this.conn = conn;
-        this.maxReqsPerSolve = maxReqsPerSolve;
-        this.maxTimePerSolve = maxTimePerSolve;
-        this.pollInterval = pollInterval;
-        this.udpSocket = new DatagramSocket();
-        this.ip = ip;
-        this.port = port;
-    }
-
-    public boolean runModelAndUpdateDB() throws IOException {
-        final Result<? extends Record> results;
-        try {
-            results = model.solve("PENDING");
-        } catch (ModelException | SolverException e) {
-            LOG.error(e);
-            return false;
-        }
-
-        // TODO: should find a way to batch these, both to/from database but also in communication with controller
-        // Add new assignments to placed, remove new assignments from pending, notify listener of changes
-        for (final Record record : results) {
-            conn.insertInto(PLACED_TABLE, PLACED_TABLE.APPLICATION, PLACED_TABLE.NODE, PLACED_TABLE.CORES,
-                            PLACED_TABLE.MEMSLICES)
-                    .values((Integer) record.get("APPLICATION"), (Integer) record.get("CONTROLLABLE__NODE"), 
-                            (Integer) record.get("CORES"), (Integer) record.get("MEMSLICES"))
-                    .onDuplicateKeyUpdate()
-                    .set(PLACED_TABLE.CORES,  PLACED_TABLE.CORES.plus((Integer) record.get("CORES")))
-                    .set(PLACED_TABLE.MEMSLICES, PLACED_TABLE.MEMSLICES.plus((Integer) record.get("MEMSLICES")))
-                    .execute();
-            conn.deleteFrom(PENDING_TABLE)
-                    .where(PENDING_TABLE.ID.eq((Long) record.get("ID")))
-                    .execute();
-
-                // TODO: move allocation out of loop
-                final SchedulerAssignment assignment = new SchedulerAssignment((Long) record.get("ID"), ((Integer) 
-                record.get("CONTROLLABLE__NODE")).longValue());
-                final DatagramPacket packet = new DatagramPacket(assignment.toBytes(), SchedulerAssignment.BYTE_LEN);
-                packet.setAddress(this.ip);
-                packet.setPort(this.port);
-                this.udpSocket.send(packet);
-                this.allocationsSent += 1;
-                LOG.info("Sent allocation for {}", (Long) record.get("ID"));
-                this.udpSocket.receive(packet);
-        }
-
-        LOG.info("Requests Recevied: {}, Allocations Sent: {}", this.requestsReceived, this.allocationsSent);
-        return true;
-    }
-
-    private int getNumPendingRequests() {
-        final String numRequests = "select count(1) from pending";
-        return ((Long) this.conn.fetch(numRequests).get(0).getValue(0)).intValue();
-    }
-
-    public void run() throws InterruptedException, IOException {
-
-        class RequestHandler extends RPCHandler {
-            private long requestId = 0;
-            private Scheduler scheduler;
-
-            public RequestHandler(final Scheduler scheduler) {
-                this.scheduler = scheduler;
-            }
-
-            @Override
-            public RPCMessage handleRPC(final RPCMessage msg) {
-                final RPCHeader hdr = msg.hdr();
-                assert (hdr.msgLen == SchedulerRequest.BYTE_LEN);
-                final SchedulerRequest req = new SchedulerRequest(msg.payload());
-
-                conn.insertInto(PENDING_TABLE)
-                        .set(PENDING_TABLE.ID, requestId)
-                        .set(PENDING_TABLE.APPLICATION, (int) req.application)
-                        .set(PENDING_TABLE.CORES, (int) req.cores)
-                        .set(PENDING_TABLE.MEMSLICES, (int) req.memslices)
-                        .set(PENDING_TABLE.STATUS, "PENDING")
-                        .set(PENDING_TABLE.CURRENT_NODE, -1)
-                        .set(PENDING_TABLE.CONTROLLABLE__NODE, (Field<Integer>) null)
-                        .execute();
-
-                hdr.msgLen = SchedulerResponse.BYTE_LEN;
-                scheduler.requestsReceived++;
-                return new RPCMessage(hdr, new SchedulerResponse(requestId++).toBytes());
-            }
-        }
-
-        final Runnable rpcRunner =
-                () -> {
-                    try {
-                        LOG.info("RPCServer thread started");
-                        final RPCServer rpcServer = new TCPServer("172.31.0.20", 6970);
-                        LOG.info("Created server");
-                        rpcServer.register((byte) 1, new RequestHandler(this));
-                        LOG.info("Registered handler");
-                        rpcServer.addClient();
-                        LOG.info("Added Client");
-                        rpcServer.runServer();
-                    } catch (final IOException e) {
-                        LOG.error("RPCServer thread failed");
-                        LOG.error(e);
-                        throw new RuntimeException();
-                    }
-                };
-        final Thread thread = new Thread(rpcRunner);
-        thread.start();
-
-        // Enter loop solve loop
-        long lastSolve = System.currentTimeMillis();
-        while (true) {
-            // Sleep for poll interval
-            Thread.sleep(this.pollInterval);
-
-            // Get time elapsed since last solve
-            final long timeElapsed = System.currentTimeMillis() - lastSolve;
-
-            // Get number of rows
-            final int numRequests = this.getNumPendingRequests();
-
-            // If time since last solve is too long, solve
-            if (timeElapsed >= this.maxTimePerSolve || numRequests >= this.maxReqsPerSolve) {
-                if (timeElapsed >= this.maxTimePerSolve) {
-                    LOG.info(String.format("solver thread solving due to timeout: numRequests = %d", numRequests));
-                } else {
-                    LOG.info(String.format("solver thread solving due to numRequests = %d", numRequests));
-                }
-                // Only actually solve if work to do
-                if (numRequests > 0) {
-                    // Exit if solver error
-                    if (!this.runModelAndUpdateDB()) {
-                        break;
-                    }
-                }
-                lastSolve = System.currentTimeMillis();
-            }
-        } // while (true)
-    }
-}
-
 
 public class SchedulerRunner extends DCMRunner {
     private static final Logger LOG = LogManager.getLogger(SchedulerRunner.class);
-    private static final String NUM_NODES_OPTION = "numNodes";
-    private static final int NUM_NODES_DEFAULT = 64;
-    private static final String CORES_PER_NODE_OPTION = "coresPerNode";
-    private static final int CORES_PER_NODE_DEFAULT = 128;
-    private static final String MEMSLICES_PER_NODE_OPTION = "memslicesPerNode";
-    private static final int MEMSLICES_PER_NODE_DEFAULT = 256;
-    private static final String NUM_APPS_OPTION = "numApps";
-    private static final int NUM_APPS_DEFAULT = 20;
     private static final String USE_CAP_FUNCTION_OPTION = "useCapFunction";
     private static final boolean USE_CAP_FUNCTION_DEFAULT = true;
     private static final String MAX_REQUESTS_PER_SOLVE_OPTION = "maxReqsPerSolve";
@@ -223,10 +42,6 @@ public class SchedulerRunner extends DCMRunner {
             SocketException, UnknownHostException, IOException {
         // These are the defaults for these parameters.
         // They should be overridden by commandline arguments.
-        int numNodes = NUM_NODES_DEFAULT;
-        int coresPerNode = CORES_PER_NODE_DEFAULT;
-        int memslicesPerNode = MEMSLICES_PER_NODE_DEFAULT;
-        int numApps = NUM_APPS_DEFAULT;
         boolean useCapFunction = USE_CAP_FUNCTION_DEFAULT;
         int maxReqsPerSolve = MAX_REQUESTS_PER_SOLVE_DEFAULT;
         long maxTimePerSolve = MAX_TIME_PER_SOLVE_DEFAULT;
@@ -239,30 +54,6 @@ public class SchedulerRunner extends DCMRunner {
                 .longOpt("help").argName("h")
                 .hasArg(false)
                 .desc("print help message")
-                .build();
-        final Option numNodesOption = Option.builder("n")
-                .longOpt(NUM_NODES_OPTION).argName(NUM_NODES_OPTION)
-                .hasArg()
-                .desc(String.format("number of nodes.%nDefault: %d", NUM_NODES_DEFAULT))
-                .type(Integer.class)
-                .build();
-        final Option coresPerNodeOption = Option.builder("c")
-                .longOpt(CORES_PER_NODE_OPTION).argName(CORES_PER_NODE_OPTION)
-                .hasArg()
-                .desc(String.format("cores per node.%nDefault: %d", CORES_PER_NODE_DEFAULT))
-                .type(Integer.class)
-                .build();
-        final Option memslicesPerNodeOption = Option.builder("m")
-                .longOpt(MEMSLICES_PER_NODE_OPTION).argName(MEMSLICES_PER_NODE_OPTION)
-                .hasArg()
-                .desc(String.format("number of 2 MB memory slices per node.%nDefault: %d", MEMSLICES_PER_NODE_DEFAULT))
-                .type(Integer.class)
-                .build();
-        final Option numAppsOption = Option.builder("p")
-                .longOpt(NUM_APPS_OPTION).argName(NUM_APPS_OPTION)
-                .hasArg()
-                .desc(String.format("number of applications running on the cluster.%nDefault: %d", NUM_APPS_DEFAULT))
-                .type(Integer.class)
                 .build();
         final Option useCapFunctionOption = Option.builder("f")
                 .longOpt(USE_CAP_FUNCTION_OPTION).argName(USE_CAP_FUNCTION_OPTION)
@@ -294,13 +85,8 @@ public class SchedulerRunner extends DCMRunner {
                 .build();
 
         options.addOption(helpOption);
-        options.addOption(numNodesOption);
-        options.addOption(coresPerNodeOption);
-        options.addOption(memslicesPerNodeOption);
-        options.addOption(numAppsOption);
         options.addOption(useCapFunctionOption);
         options.addOption(maxReqsPerSolveOption);
-        options.addOption(maxTimePerSolveOption);
         options.addOption(maxTimePerSolveOption);
         options.addOption(pollIntervalOption);
 
@@ -314,18 +100,6 @@ public class SchedulerRunner extends DCMRunner {
                                 "target/scheduler-1.0-SNAPSHOT-jar-with-dependencies.jar [options]",
                         options);
                 return;
-            }
-            if (cmd.hasOption(NUM_NODES_OPTION)) {
-                numNodes = Integer.parseInt(cmd.getOptionValue(NUM_NODES_OPTION));
-            }
-            if (cmd.hasOption(CORES_PER_NODE_OPTION)) {
-                coresPerNode = Integer.parseInt(cmd.getOptionValue(CORES_PER_NODE_OPTION));
-            }
-            if (cmd.hasOption(MEMSLICES_PER_NODE_OPTION)) {
-                memslicesPerNode = Integer.parseInt(cmd.getOptionValue(MEMSLICES_PER_NODE_OPTION));
-            }
-            if (cmd.hasOption(NUM_APPS_OPTION)) {
-                numApps = Integer.parseInt(cmd.getOptionValue(NUM_APPS_OPTION));
             }
             if (cmd.hasOption(USE_CAP_FUNCTION_OPTION)) {
                 useCapFunction = Boolean.parseBoolean(cmd.getOptionValue(USE_CAP_FUNCTION_OPTION));
@@ -347,11 +121,13 @@ public class SchedulerRunner extends DCMRunner {
         // Create an in-memory database and get a JOOQ connection to it
         Class.forName("org.h2.Driver");
         final DSLContext conn = DSL.using("jdbc:h2:mem:");
-        initDB(conn, numNodes, coresPerNode, memslicesPerNode, numApps, 0, false);
 
-        LOG.info("Running solver with parameters: nodes={}, coresPerNode={}, memSlicesPerNode={}, " +
-                        "numApps={}, useCapFunction={}, maxReqsPerSolve={}, maxTimePerSolve={}, pollInterval={}",
-                numNodes, coresPerNode, memslicesPerNode, numApps, useCapFunction, maxReqsPerSolve, maxTimePerSolve,
+        // initialize database with no resources
+        initDB(conn, 0, 0, 0, 0, 0, false);
+
+        LOG.info("Running solver with parameters: useCapFunction={}, maxReqsPerSolve={}, " +
+                        "maxTimePerSolve={}, pollInterval={}",
+                useCapFunction, maxReqsPerSolve, maxTimePerSolve,
                 pollInterval);
         final Model model = createModel(conn, useCapFunction);
         final Scheduler scheduler = new Scheduler(model, conn, maxReqsPerSolve, maxTimePerSolve, pollInterval, 

--- a/src/main/java/com/vmware/bespin/scheduler/rpc/RPCID.java
+++ b/src/main/java/com/vmware/bespin/scheduler/rpc/RPCID.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2022 VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: BSD-2 OR MIT
+ */
+
+package com.vmware.bespin.scheduler.rpc;
+
+public enum RPCID {
+    REGISTER_NODE((byte) 1),
+    SCHEDULER((byte) 2);
+
+    private final byte id;
+
+    public byte id() {
+        return this.id;
+    }
+
+    private RPCID(final byte handler_id) {
+        this.id = handler_id;
+    }
+}

--- a/src/main/java/com/vmware/bespin/scheduler/rpc/RegisterNodeHandler.java
+++ b/src/main/java/com/vmware/bespin/scheduler/rpc/RegisterNodeHandler.java
@@ -36,7 +36,7 @@ public class RegisterNodeHandler extends RPCHandler {
                 .execute();
         LOG.info("Handled register node request: {}, assigned id {}", req, requestId);
 
-        hdr.msgLen = RegisterNodeRequest.BYTE_LEN;
+        hdr.msgLen = RegisterNodeResponse.BYTE_LEN;
         return new RPCMessage(hdr, new RegisterNodeResponse(requestId++).toBytes());
     }
 }

--- a/src/main/java/com/vmware/bespin/scheduler/rpc/RegisterNodeHandler.java
+++ b/src/main/java/com/vmware/bespin/scheduler/rpc/RegisterNodeHandler.java
@@ -34,7 +34,7 @@ public class RegisterNodeHandler extends RPCHandler {
                 .set(Scheduler.NODE_TABLE.CORES, (int) req.cores)
                 .set(Scheduler.NODE_TABLE.MEMSLICES, (int) req.memslices)
                 .execute();
-        LOG.info("Registered Node {} with {} cores, {} memslices", requestId, req.cores, req.memslices);
+        LOG.info("Handled register node request: {}, assigned id {}", req, requestId);
 
         hdr.msgLen = RegisterNodeRequest.BYTE_LEN;
         return new RPCMessage(hdr, new RegisterNodeResponse(requestId++).toBytes());

--- a/src/main/java/com/vmware/bespin/scheduler/rpc/RegisterNodeHandler.java
+++ b/src/main/java/com/vmware/bespin/scheduler/rpc/RegisterNodeHandler.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: BSD-2 OR MIT
+ */
+
+package com.vmware.bespin.scheduler.rpc;
+
+import com.vmware.bespin.rpc.RPCHandler;
+import com.vmware.bespin.rpc.RPCHeader;
+import com.vmware.bespin.rpc.RPCMessage;
+import com.vmware.bespin.scheduler.Scheduler;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jooq.DSLContext;
+
+public class RegisterNodeHandler extends RPCHandler {
+    private static final Logger LOG = LogManager.getLogger(RegisterNodeHandler.class);
+
+    private int requestId = 0;
+    private DSLContext conn;
+
+    public RegisterNodeHandler(final DSLContext conn) {
+        this.conn = conn;
+    }
+
+    @Override
+    public RPCMessage handleRPC(final RPCMessage msg) {
+        final RPCHeader hdr = msg.hdr();
+        assert (hdr.msgLen == RegisterNodeRequest.BYTE_LEN);
+        final RegisterNodeRequest req = new RegisterNodeRequest(msg.payload());
+
+        conn.insertInto(Scheduler.NODE_TABLE)
+                .set(Scheduler.NODE_TABLE.ID, requestId)
+                .set(Scheduler.NODE_TABLE.CORES, (int) req.cores)
+                .set(Scheduler.NODE_TABLE.MEMSLICES, (int) req.memslices)
+                .execute();
+        LOG.info("Registered Node {} with {} cores, {} memslices", requestId, req.cores, req.memslices);
+
+        hdr.msgLen = RegisterNodeRequest.BYTE_LEN;
+        return new RPCMessage(hdr, new RegisterNodeResponse(requestId++).toBytes());
+    }
+}

--- a/src/main/java/com/vmware/bespin/scheduler/rpc/RegisterNodeRequest.java
+++ b/src/main/java/com/vmware/bespin/scheduler/rpc/RegisterNodeRequest.java
@@ -5,11 +5,13 @@
 
 package com.vmware.bespin.scheduler.rpc;
 
-public class RegisterNodeRequest {
-    public static final int BYTE_LEN = 2;
+import com.vmware.bespin.rpc.Utils;
 
-    final byte cores;
-    final byte memslices;
+public class RegisterNodeRequest {
+    public static final int BYTE_LEN = Long.BYTES * 2;
+
+    final long cores;
+    final long memslices;
 
     public RegisterNodeRequest(final byte cores, final byte memslices) {
         this.cores = cores;
@@ -18,15 +20,19 @@ public class RegisterNodeRequest {
 
     public RegisterNodeRequest(final byte[] data) {
         assert (data.length == RegisterNodeRequest.BYTE_LEN);
-
-        this.cores = data[0];
-        this.memslices = data[1];
+        this.cores = Utils.bytesToLong(data, 0);
+        this.memslices = Utils.bytesToLong(data, Long.BYTES);
     }
 
     public byte[] toBytes() {
         final byte[] buff = new byte[RegisterNodeRequest.BYTE_LEN];
-        buff[0] = this.cores;
-        buff[1] = this.memslices;
-        return buff;
+        Utils.longToBytes(this.cores, buff, 0);
+        Utils.longToBytes(this.memslices, buff, Long.BYTES);
+	return buff;
+    }
+
+    @Override
+    public String toString() {
+        return "RegisterNodeRequest(cores=" + this.cores + ", memslices=" + this.memslices + ")";
     }
 }

--- a/src/main/java/com/vmware/bespin/scheduler/rpc/RegisterNodeRequest.java
+++ b/src/main/java/com/vmware/bespin/scheduler/rpc/RegisterNodeRequest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: BSD-2 OR MIT
+ */
+
+package com.vmware.bespin.scheduler.rpc;
+
+public class RegisterNodeRequest {
+    public static final int BYTE_LEN = 2;
+
+    final byte cores;
+    final byte memslices;
+
+    public RegisterNodeRequest(final byte cores, final byte memslices) {
+        this.cores = cores;
+        this.memslices = memslices;
+    }
+
+    public RegisterNodeRequest(final byte[] data) {
+        assert (data.length == RegisterNodeRequest.BYTE_LEN);
+
+        this.cores = data[0];
+        this.memslices = data[1];
+    }
+
+    public byte[] toBytes() {
+        final byte[] buff = new byte[RegisterNodeRequest.BYTE_LEN];
+        buff[0] = this.cores;
+        buff[1] = this.memslices;
+        return buff;
+    }
+}

--- a/src/main/java/com/vmware/bespin/scheduler/rpc/RegisterNodeResponse.java
+++ b/src/main/java/com/vmware/bespin/scheduler/rpc/RegisterNodeResponse.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: BSD-2 OR MIT
+ */
+
+package com.vmware.bespin.scheduler.rpc;
+
+import com.vmware.bespin.rpc.Utils;
+
+public class RegisterNodeResponse {
+    public static final int BYTE_LEN = Long.BYTES;
+
+    final long nodeId;
+
+    public RegisterNodeResponse(final long nodeId) {
+        this.nodeId = nodeId;
+    }
+
+    public RegisterNodeResponse(final byte[] data) {
+        assert (data.length == RegisterNodeResponse.BYTE_LEN);
+        this.nodeId = Utils.bytesToLong(data, 0);
+    }
+
+    public byte[] toBytes() {
+        final byte[] buff = new byte[RegisterNodeResponse.BYTE_LEN];
+        Utils.longToBytes(this.nodeId, buff, 0);
+        return buff;
+    }
+}

--- a/src/main/java/com/vmware/bespin/scheduler/rpc/SchedulerHandler.java
+++ b/src/main/java/com/vmware/bespin/scheduler/rpc/SchedulerHandler.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2022 VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: BSD-2 OR MIT
+ */
+
+package com.vmware.bespin.scheduler.rpc;
+
+import com.vmware.bespin.rpc.RPCHandler;
+import com.vmware.bespin.rpc.RPCHeader;
+import com.vmware.bespin.rpc.RPCMessage;
+import com.vmware.bespin.scheduler.Scheduler;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jooq.DSLContext;
+import org.jooq.Field;
+
+public class SchedulerHandler extends RPCHandler {
+    private static final Logger LOG = LogManager.getLogger(SchedulerHandler.class);
+    private long requestId = 0;
+    private DSLContext conn;
+
+    public SchedulerHandler(final DSLContext conn) {
+        this.conn = conn;
+    }
+
+    @Override
+    public RPCMessage handleRPC(final RPCMessage msg) {
+        final RPCHeader hdr = msg.hdr();
+        assert (hdr.msgLen == SchedulerRequest.BYTE_LEN);
+        final SchedulerRequest req = new SchedulerRequest(msg.payload());
+
+        // Add application to application table if new
+        conn.insertInto(Scheduler.APPLICATION_TABLE)
+                .set(Scheduler.APPLICATION_TABLE.ID, (int) req.application)
+                .onDuplicateKeyIgnore()
+                .execute();
+
+        // Add request to pending table
+        conn.insertInto(Scheduler.PENDING_TABLE)
+                .set(Scheduler.PENDING_TABLE.ID, requestId)
+                .set(Scheduler.PENDING_TABLE.APPLICATION, (int) req.application)
+                .set(Scheduler.PENDING_TABLE.CORES, (int) req.cores)
+                .set(Scheduler.PENDING_TABLE.MEMSLICES, (int) req.memslices)
+                .set(Scheduler.PENDING_TABLE.STATUS, "PENDING")
+                .set(Scheduler.PENDING_TABLE.CURRENT_NODE, -1)
+                .set(Scheduler.PENDING_TABLE.CONTROLLABLE__NODE, (Field<Integer>) null)
+                .execute();
+        LOG.info("Processed scheduler request for app {} with {} cores, {} memslices",
+                req.application, req.cores, req.memslices);
+
+        hdr.msgLen = SchedulerResponse.BYTE_LEN;
+        return new RPCMessage(hdr, new SchedulerResponse(requestId++).toBytes());
+    }
+}

--- a/src/main/java/com/vmware/bespin/scheduler/rpc/SchedulerHandler.java
+++ b/src/main/java/com/vmware/bespin/scheduler/rpc/SchedulerHandler.java
@@ -45,8 +45,7 @@ public class SchedulerHandler extends RPCHandler {
                 .set(Scheduler.PENDING_TABLE.CURRENT_NODE, -1)
                 .set(Scheduler.PENDING_TABLE.CONTROLLABLE__NODE, (Field<Integer>) null)
                 .execute();
-        LOG.info("Processed scheduler request for app {} with {} cores, {} memslices",
-                req.application, req.cores, req.memslices);
+        LOG.info("Processed scheduler request: {}", req);
 
         hdr.msgLen = SchedulerResponse.BYTE_LEN;
         return new RPCMessage(hdr, new SchedulerResponse(requestId++).toBytes());

--- a/src/main/java/com/vmware/bespin/scheduler/rpc/SchedulerRequest.java
+++ b/src/main/java/com/vmware/bespin/scheduler/rpc/SchedulerRequest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BSD-2 OR MIT
  */
 
-package com.vmware.bespin.scheduler;
+package com.vmware.bespin.scheduler.rpc;
 
 public class SchedulerRequest {
     public static final int BYTE_LEN = 3;

--- a/src/main/java/com/vmware/bespin/scheduler/rpc/SchedulerRequest.java
+++ b/src/main/java/com/vmware/bespin/scheduler/rpc/SchedulerRequest.java
@@ -5,12 +5,14 @@
 
 package com.vmware.bespin.scheduler.rpc;
 
-public class SchedulerRequest {
-    public static final int BYTE_LEN = 3;
+import com.vmware.bespin.rpc.Utils;
 
-    final byte application;
-    final byte cores;
-    final byte memslices;
+public class SchedulerRequest {
+    public static final int BYTE_LEN = Long.BYTES * 3;
+
+    final long application;
+    final long cores;
+    final long memslices;
 
     public SchedulerRequest(final byte application, final byte cores, final byte memslices) {
         this.application = application;
@@ -21,16 +23,22 @@ public class SchedulerRequest {
     public SchedulerRequest(final byte[] data) {
         assert (data.length == SchedulerRequest.BYTE_LEN);
 
-        this.application = data[0];
-        this.cores = data[1];
-        this.memslices = data[2];
+        this.application = Utils.bytesToLong(data, 0);
+        this.cores = Utils.bytesToLong(data, Long.BYTES);
+        this.memslices = Utils.bytesToLong(data, Long.BYTES * 2);
     }
 
     public byte[] toBytes() {
         final byte[] buff = new byte[SchedulerRequest.BYTE_LEN];
-        buff[0] = this.application;
-        buff[1] = this.cores;
-        buff[2] = this.memslices;
-        return buff;
+        Utils.longToBytes(this.application, buff, 0);
+        Utils.longToBytes(this.cores, buff, Long.BYTES);
+        Utils.longToBytes(this.memslices, buff, Long.BYTES * 2);
+	return buff;
+    }
+
+    @Override
+    public String toString() {
+        return "SchedulerRequest(app=" + this.application + ", cores=" + this.cores + 
+            ", memslices=" + this.memslices + ")";
     }
 }

--- a/src/main/java/com/vmware/bespin/scheduler/rpc/SchedulerResponse.java
+++ b/src/main/java/com/vmware/bespin/scheduler/rpc/SchedulerResponse.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BSD-2 OR MIT
  */
 
-package com.vmware.bespin.scheduler;
+package com.vmware.bespin.scheduler.rpc;
 
 import com.vmware.bespin.rpc.Utils;
 

--- a/src/test/java/com/vmware/bespin/scheduler/TestSerialization.java
+++ b/src/test/java/com/vmware/bespin/scheduler/TestSerialization.java
@@ -8,34 +8,14 @@ package com.vmware.bespin.scheduler;
 import org.junit.jupiter.api.Test;
 
 public class TestSerialization {
-    
+
     @Test
     public void testAssignment() {
         SchedulerAssignment assignment = new SchedulerAssignment(1, 2);
         byte[] b = assignment.toBytes();
-        assert(b.length == SchedulerAssignment.BYTE_LEN);
+        assert (b.length == SchedulerAssignment.BYTE_LEN);
         SchedulerAssignment assignment2 = new SchedulerAssignment(b);
-        assert(assignment2.requestId == assignment.requestId);
-        assert(assignment2.node == assignment.node);
-    }
-
-    @Test
-    public void testRequest() {
-        SchedulerRequest req = new SchedulerRequest((byte) 3, (byte) 4, (byte) 5);
-        byte[] b = req.toBytes();
-        assert(b.length == SchedulerRequest.BYTE_LEN);
-        SchedulerRequest req2 = new SchedulerRequest(b);
-        assert(req2.application == req.application);
-        assert(req2.cores == req.cores);
-        assert(req2.memslices == req.memslices);
-    }
-
-    @Test
-    public void testResponse() {
-        SchedulerResponse res = new SchedulerResponse(35);
-        byte[] b = res.toBytes();
-        assert(b.length == SchedulerResponse.BYTE_LEN);
-        SchedulerResponse res2 = new SchedulerResponse(b);
-        assert(res2.requestId == res.requestId);
+        assert (assignment2.requestId == assignment.requestId);
+        assert (assignment2.node == assignment.node);
     }
 }

--- a/src/test/java/com/vmware/bespin/scheduler/rpc/TestSerialization.java
+++ b/src/test/java/com/vmware/bespin/scheduler/rpc/TestSerialization.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: BSD-2 OR MIT
+ */
+
+package com.vmware.bespin.scheduler.rpc;
+
+import org.junit.jupiter.api.Test;
+
+public class TestSerialization {
+
+    @Test
+    public void testSchedulerRequest() {
+        SchedulerRequest req = new SchedulerRequest((byte) 3, (byte) 4, (byte) 5);
+        byte[] b = req.toBytes();
+        assert(b.length == SchedulerRequest.BYTE_LEN);
+        SchedulerRequest req2 = new SchedulerRequest(b);
+        assert(req2.application == req.application);
+        assert(req2.cores == req.cores);
+        assert(req2.memslices == req.memslices);
+    }
+
+    @Test
+    public void testSchedulerResponse() {
+        SchedulerResponse res = new SchedulerResponse(35);
+        byte[] b = res.toBytes();
+        assert(b.length == SchedulerResponse.BYTE_LEN);
+        SchedulerResponse res2 = new SchedulerResponse(b);
+        assert(res2.requestId == res.requestId);
+    }
+
+    @Test
+    public void testRegisterNodeRequest() {
+        RegisterNodeRequest req = new RegisterNodeRequest((byte) 3, (byte) 4);
+        byte[] b = req.toBytes();
+        assert(b.length == RegisterNodeRequest.BYTE_LEN);
+        RegisterNodeRequest req2 = new RegisterNodeRequest(b);
+        assert(req2.cores == req.cores);
+        assert(req2.memslices == req.memslices);
+    }
+
+    @Test
+    public void testRegisterNodeResponse() {
+        RegisterNodeResponse res = new RegisterNodeResponse(35);
+        byte[] b = res.toBytes();
+        assert(b.length == RegisterNodeResponse.BYTE_LEN);
+        RegisterNodeResponse res2 = new RegisterNodeResponse(b);
+        assert(res2.nodeId == res.nodeId);
+    }
+}


### PR DESCRIPTION
Add code to make the scheduler resources dynamic. A client will use an RPC to indicate when a node joins the cluster, and DCM will add the node (and associated cores and memslices) into the database. Applications will also be created on the fly, when a request with a new application (pid) is received.