### PR TITLE
Affinity alloc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,9 +23,9 @@
     <dependencies>
         <!-- https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java -->
         <dependency>
-            <groupId>com.google.protobuf</groupId>
-            <artifactId>protobuf-java</artifactId>
-            <version>3.19.4</version>
+          <groupId>com.google.protobuf</groupId>
+          <artifactId>protobuf-java</artifactId>
+          <version>[3.19.6]</version>
         </dependency>
         <dependency>
             <groupId>com.vmware.dcm</groupId>

--- a/src/main/java/com/vmware/bespin/rpc/RPCHeader.java
+++ b/src/main/java/com/vmware/bespin/rpc/RPCHeader.java
@@ -6,38 +6,26 @@
 package com.vmware.bespin.rpc;
 
 public class RPCHeader {
-        public static final int BYTE_LEN = Long.BYTES * 5;
+        public static final int BYTE_LEN = Long.BYTES * 2;
 
-        public final long clientId;    // 8 bytes
-        public final long pid;         // 8 bytes
-        public final long reqId;       // 8 bytes
         private final long msgType;     // 8 byte
-        public long msgLen;            // 8 bytes
+        public long msgLen;             // 8 bytes
 
-        public RPCHeader(final long clientId, final long pid, final long reqId, final long msgType, final long msgLen) {
-                this.clientId = clientId;
-                this.pid = pid;
-                this.reqId = reqId;
+        public RPCHeader(final long msgType, final long msgLen) {
                 this.msgType = msgType;
                 this.msgLen = msgLen;
         }
 
         public RPCHeader(final byte[] data) {
                 assert (data.length == RPCHeader.BYTE_LEN);
-                this.clientId = Utils.bytesToLong(data, 0);
-                this.pid = Utils.bytesToLong(data, Long.BYTES);
-                this.reqId = Utils.bytesToLong(data, Long.BYTES * 2);
-                this.msgType = Utils.bytesToLong(data, Long.BYTES * 3);
-                this.msgLen = Utils.bytesToLong(data, Long.BYTES * 4);
+                this.msgType = Utils.bytesToLong(data, 0);
+                this.msgLen = Utils.bytesToLong(data, Long.BYTES);
         }
 
         public byte[] toBytes() {
                 final byte[] buff = new byte[RPCHeader.BYTE_LEN];
-                Utils.longToBytes(this.clientId, buff, 0);
-                Utils.longToBytes(this.pid, buff, Long.BYTES);
-                Utils.longToBytes(this.reqId, buff, Long.BYTES * 2);
-                Utils.longToBytes(this.msgType, buff, Long.BYTES * 3);
-                Utils.longToBytes(this.msgLen, buff, Long.BYTES * 4);
+                Utils.longToBytes(this.msgType, buff, 0);
+                Utils.longToBytes(this.msgLen, buff, Long.BYTES);
                 return buff;
         }
 
@@ -47,7 +35,6 @@ public class RPCHeader {
 
         @Override
         public String toString() {
-                return String.format("RPCHdr(id=%d, pid=%d, reqId=%d, type=%d, len=%d)", 
-                                        this.clientId, this.pid, this.reqId, this.msgType, this.msgLen);
+                return String.format("RPCHdr(type=%d, len=%d)", this.msgType, this.msgLen);
         }
 }

--- a/src/main/java/com/vmware/bespin/scheduler/Scheduler.java
+++ b/src/main/java/com/vmware/bespin/scheduler/Scheduler.java
@@ -12,6 +12,8 @@ import com.vmware.bespin.scheduler.rpc.RPCID;
 import com.vmware.bespin.scheduler.rpc.RegisterNodeHandler;
 import com.vmware.bespin.scheduler.rpc.AllocHandler;
 import com.vmware.bespin.scheduler.rpc.ReleaseHandler;
+import com.vmware.bespin.scheduler.rpc.AffinityAllocHandler;
+import com.vmware.bespin.scheduler.rpc.AffinityReleaseHandler;
 import com.vmware.dcm.Model;
 import com.vmware.dcm.ModelException;
 import com.vmware.dcm.SolverException;
@@ -121,6 +123,8 @@ public class Scheduler {
                         rpcServer.register(RPCID.REGISTER_NODE, new RegisterNodeHandler(conn));
                         rpcServer.register(RPCID.ALLOC, new AllocHandler(conn));
                         rpcServer.register(RPCID.RELEASE, new ReleaseHandler(conn));
+                        rpcServer.register(RPCID.AFFINITY_ALLOC, new AffinityAllocHandler(conn));
+                        rpcServer.register(RPCID.AFFINITY_RELEASE, new AffinityReleaseHandler(conn));
                         LOG.info("Registered handlers");
                         rpcServer.addClient();
                         LOG.info("Added Client");

--- a/src/main/java/com/vmware/bespin/scheduler/rpc/AffinityAllocHandler.java
+++ b/src/main/java/com/vmware/bespin/scheduler/rpc/AffinityAllocHandler.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2023 University of Colorado, VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: BSD-2 OR MIT
+ */
+
+package com.vmware.bespin.scheduler.rpc;
+
+import com.vmware.bespin.rpc.RPCHandler;
+import com.vmware.bespin.rpc.RPCHeader;
+import com.vmware.bespin.rpc.RPCMessage;
+import com.vmware.bespin.scheduler.Scheduler;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jooq.DSLContext;
+import org.jooq.Record;
+import org.jooq.Result;
+
+
+public class AffinityAllocHandler extends RPCHandler {
+    private static final Logger LOG = LogManager.getLogger(AffinityAllocHandler.class);
+    private DSLContext conn;
+
+    public AffinityAllocHandler(final DSLContext conn) {
+        this.conn = conn;
+    }
+
+    @Override
+    public RPCMessage handleRPC(final RPCMessage msg) {
+        final RPCHeader hdr = msg.hdr();
+        final AffinityRequest req = new AffinityRequest(msg.payload());
+        boolean requestFulfilled = false;
+
+        // Fetch capacity of the node
+        final Result<Record> memsliceData = this.conn.fetch(
+            String.format("select memslices from nodes where id = %d", req.nodeId));
+        final Result<Record> coreData = this.conn.fetch(
+            String.format("select cores from nodes where id = %d", req.nodeId));
+        final Result<Record> usedMemsliceData = this.conn.fetch(String.format(
+                "select sum(placed.memslices) from placed where node = %d", req.nodeId));
+        final Result<Record> usedCoreData = this.conn.fetch(String.format(
+            "select sum(placed.cores) from placed where node = %d", req.nodeId));
+
+        if (null != memsliceData && memsliceData.isNotEmpty() && null != coreData && coreData.isNotEmpty()
+                && null != usedMemsliceData && usedMemsliceData.isNotEmpty() && 
+                null != usedCoreData && usedCoreData.isNotEmpty()) {
+            try {
+                final long memslices = Integer.toUnsignedLong((int) memsliceData.get(0).getValue(0));
+                final long cores = Integer.toUnsignedLong((int) coreData.get(0).getValue(0));
+
+                // If no pending, these values may be null. That's fine, we know the value is zero in that case.
+                long usedMemslices = 0;
+                long usedCores = 0;
+                try {
+                    usedCores += (long) usedCoreData.get(0).getValue(0);
+                } catch (final NullPointerException e) { }
+                try {
+                    usedMemslices += (long) usedMemsliceData.get(0).getValue(0);
+                } catch (final NullPointerException e) { }
+
+                // There is enough memory to fulfill the alloc request!
+                if (memslices >= usedMemslices + req.memslices && cores >= usedCores + req.cores) {
+                    // Subtract from the overall node resource
+                    conn.update(Scheduler.NODE_TABLE)
+                        .set(Scheduler.NODE_TABLE.MEMSLICES, Scheduler.NODE_TABLE.MEMSLICES.sub(req.memslices))
+                        .set(Scheduler.NODE_TABLE.CORES, Scheduler.NODE_TABLE.CORES.sub(req.cores))
+                        .where(Scheduler.NODE_TABLE.ID.eq((int) req.nodeId))
+                        .execute();
+                    requestFulfilled = true;
+                }
+
+                LOG.info("Processed scheduler affinity request: {}, cores: {}, " +
+                    "cores_used: {}, memslices: {}, memslices_used: {}, ret: {}", 
+                    req, cores, usedCores, memslices, usedMemslices, requestFulfilled);
+            } catch (final NumberFormatException e) {
+                LOG.info("Failed to unpack memslices/cores correctly: {}", e.toString());
+            }
+        } else {
+            LOG.warn("Failed to process scheduler affinity alloc request because memslice " +
+            "data for node {} not found", req.nodeId);
+        }
+
+        hdr.msgLen = AffinityResponse.BYTE_LEN;
+        return new RPCMessage(hdr, new AffinityResponse(requestFulfilled).toBytes());
+    }
+}

--- a/src/main/java/com/vmware/bespin/scheduler/rpc/AffinityReleaseHandler.java
+++ b/src/main/java/com/vmware/bespin/scheduler/rpc/AffinityReleaseHandler.java
@@ -1,0 +1,41 @@
+package com.vmware.bespin.scheduler.rpc;
+
+import com.vmware.bespin.rpc.RPCHandler;
+import com.vmware.bespin.rpc.RPCHeader;
+/*
+ * Copyright 2023 University of Colorado, VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: BSD-2 OR MIT
+ */
+
+import com.vmware.bespin.rpc.RPCMessage;
+import com.vmware.bespin.scheduler.Scheduler;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jooq.DSLContext;
+
+
+public class AffinityReleaseHandler extends RPCHandler {
+    private static final Logger LOG = LogManager.getLogger(AffinityReleaseHandler.class);
+    private DSLContext conn;
+
+    public AffinityReleaseHandler(final DSLContext conn) {
+        this.conn = conn;
+    }
+
+    @Override
+    public RPCMessage handleRPC(final RPCMessage msg) {
+        final RPCHeader hdr = msg.hdr();
+        final AffinityRequest req = new AffinityRequest(msg.payload());
+
+        // Add to the node capacity
+        conn.update(Scheduler.NODE_TABLE)
+            .set(Scheduler.NODE_TABLE.CORES, Scheduler.NODE_TABLE.CORES.add(req.cores))
+            .set(Scheduler.NODE_TABLE.MEMSLICES, Scheduler.NODE_TABLE.MEMSLICES.add(req.memslices))
+            .where(Scheduler.NODE_TABLE.ID.eq((int) req.nodeId))
+            .execute();
+
+        LOG.info("Processed scheduler affinity release request: {}", req); 
+        hdr.msgLen = AffinityResponse.BYTE_LEN;
+        return new RPCMessage(hdr, new AffinityResponse(true).toBytes());
+    }
+}

--- a/src/main/java/com/vmware/bespin/scheduler/rpc/AffinityRequest.java
+++ b/src/main/java/com/vmware/bespin/scheduler/rpc/AffinityRequest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 University of Colorado, VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: BSD-2 OR MIT
+ */
+
+ package com.vmware.bespin.scheduler.rpc;
+
+ import com.vmware.bespin.rpc.Utils;
+ 
+ public class AffinityRequest {
+     public static final int BYTE_LEN = Long.BYTES * 3;
+ 
+     final long nodeId;
+     final long cores;
+     final long memslices;
+ 
+     public AffinityRequest(final byte nodeId, final byte cores, final byte memslices) {
+         this.nodeId = nodeId;
+         this.cores = cores;
+         this.memslices = memslices;
+     }
+ 
+     public AffinityRequest(final byte[] data) {
+         assert (data.length == AffinityRequest.BYTE_LEN);
+ 
+         this.nodeId = Utils.bytesToLong(data, 0);
+         this.cores = Utils.bytesToLong(data, Long.BYTES);
+         this.memslices = Utils.bytesToLong(data, Long.BYTES * 2);
+     }
+ 
+     public byte[] toBytes() {
+         final byte[] buff = new byte[AffinityRequest.BYTE_LEN];
+         Utils.longToBytes(this.nodeId, buff, 0);
+         Utils.longToBytes(this.cores, buff, Long.BYTES);
+         Utils.longToBytes(this.memslices, buff, Long.BYTES * 2);
+     return buff;
+     }
+ 
+     @Override
+     public String toString() {
+         return "AffinityAllocRequest(node=" + this.nodeId + ", cores=" + this.cores +
+         ", memslices=" + this.memslices + ")";
+     }
+ }
+ 

--- a/src/main/java/com/vmware/bespin/scheduler/rpc/AffinityResponse.java
+++ b/src/main/java/com/vmware/bespin/scheduler/rpc/AffinityResponse.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023 University of Colorado, VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: BSD-2 OR MIT
+ */
+
+ package com.vmware.bespin.scheduler.rpc;
+ 
+ public class AffinityResponse {
+     public static final int BYTE_LEN = 1;
+ 
+     final byte requestFulfilled;
+ 
+     public AffinityResponse(final boolean requestFulfilled) {
+         this.requestFulfilled = (byte) (requestFulfilled ? 1 : 0);
+     }
+ 
+     public AffinityResponse(final byte[] data) {
+         assert (data.length == AffinityResponse.BYTE_LEN);
+         this.requestFulfilled = data[0];
+     }
+ 
+     public byte[] toBytes() {
+         final byte[] buff = new byte[AffinityResponse.BYTE_LEN];
+         buff[0] = this.requestFulfilled;
+         return buff;
+     }
+ }
+ 

--- a/src/main/java/com/vmware/bespin/scheduler/rpc/RPCID.java
+++ b/src/main/java/com/vmware/bespin/scheduler/rpc/RPCID.java
@@ -8,7 +8,9 @@ package com.vmware.bespin.scheduler.rpc;
 public enum RPCID {
     REGISTER_NODE((byte) 1),
     ALLOC((byte) 2),
-    RELEASE((byte) 3);
+    RELEASE((byte) 3),
+    AFFINITY_ALLOC((byte) 4),
+    AFFINITY_RELEASE((byte) 5);
 
     private final byte id;
 

--- a/src/test/java/com/vmware/bespin/rpc/TestRPCHeader.java
+++ b/src/test/java/com/vmware/bespin/rpc/TestRPCHeader.java
@@ -11,13 +11,10 @@ public class TestRPCHeader {
 
     @Test
     public void testConversion() {
-        RPCHeader hdr = new RPCHeader(1L, 2L, 3L, (byte) 4, 5L);
+        RPCHeader hdr = new RPCHeader((byte) 4, 5L);
         byte[] b = hdr.toBytes();
         assert(b.length == RPCHeader.BYTE_LEN);
         RPCHeader hdr2 = new RPCHeader(b);
-        assert(hdr2.clientId == hdr.clientId);
-        assert(hdr2.pid == hdr.pid);
-        assert(hdr2.reqId == hdr.reqId);
         assert(hdr2.getType() == hdr.getType());
         assert(hdr2.msgLen == hdr.msgLen);
     }

--- a/src/test/java/com/vmware/bespin/scheduler/rpc/TestSerialization.java
+++ b/src/test/java/com/vmware/bespin/scheduler/rpc/TestSerialization.java
@@ -67,4 +67,24 @@ public class TestSerialization {
         RegisterNodeResponse res2 = new RegisterNodeResponse(b);
         assert(res2.nodeId == res.nodeId);
     }
+
+    @Test
+    public void testAffinityRequest() {
+        AffinityRequest req = new AffinityRequest((byte) 6, (byte) 7, (byte) 8);
+        byte[] b = req.toBytes();
+        assert(b.length == AffinityRequest.BYTE_LEN);
+        AffinityRequest req2 = new AffinityRequest(b);
+        assert(req2.nodeId == req.nodeId);
+        assert(req2.cores == req.cores);
+        assert(req2.memslices == req.memslices);
+    }
+
+    @Test
+    public void testAffinityResponse() {
+        AffinityResponse res = new AffinityResponse(true);
+        byte[] b = res.toBytes();
+        assert(b.length == AffinityResponse.BYTE_LEN);
+        AffinityResponse res2 = new AffinityResponse(b);
+        assert(res2.requestFulfilled == res.requestFulfilled);
+    }
 }


### PR DESCRIPTION
Added AffinityAlloc and AffinityRelease RPCs that allocates memory of a certain affinity (if it is available) without solving with DCM. 

AffinityAlloc is tested but AffinityRelease has not been tested, as NRK does not yet need/implement this command.