### PR TITLE
Add node id to node registration request

### DIFF
--- a/src/main/java/com/vmware/bespin/scheduler/rpc/RegisterNodeHandler.java
+++ b/src/main/java/com/vmware/bespin/scheduler/rpc/RegisterNodeHandler.java
@@ -14,8 +14,7 @@ import org.apache.logging.log4j.Logger;
 
 public class RegisterNodeHandler extends RPCHandler<DCMRunner> {
     private static final Logger LOG = LogManager.getLogger(RegisterNodeHandler.class);
-    private int requestId = 0;
-
+    
     public RegisterNodeHandler() { }
 
     @Override
@@ -24,10 +23,10 @@ public class RegisterNodeHandler extends RPCHandler<DCMRunner> {
         assert (hdr.msgLen == RegisterNodeRequest.BYTE_LEN);
         final RegisterNodeRequest req = new RegisterNodeRequest(msg.payload());
 
-        runner.addNode(requestId, req.cores, req.memslices);
-        LOG.info("Handled register node request: {}, assigned id {}", req, requestId);
+        runner.addNode(req.id, req.cores, req.memslices);
+        LOG.info("Handled register node request: {}, assigned id {}", req, req.id);
 
         hdr.msgLen = RegisterNodeResponse.BYTE_LEN;
-        return new RPCMessage(hdr, new RegisterNodeResponse(requestId++).toBytes());
+        return new RPCMessage(hdr, new RegisterNodeResponse(true).toBytes());
     }
 }

--- a/src/main/java/com/vmware/bespin/scheduler/rpc/RegisterNodeRequest.java
+++ b/src/main/java/com/vmware/bespin/scheduler/rpc/RegisterNodeRequest.java
@@ -8,31 +8,36 @@ package com.vmware.bespin.scheduler.rpc;
 import com.vmware.bespin.rpc.Utils;
 
 public class RegisterNodeRequest {
-    public static final int BYTE_LEN = Long.BYTES * 2;
+    public static final int BYTE_LEN = Long.BYTES * 3;
 
+    final long id;
     final long cores;
     final long memslices;
 
-    public RegisterNodeRequest(final byte cores, final byte memslices) {
+    public RegisterNodeRequest(final long id, final byte cores, final byte memslices) {
+        this.id = id;
         this.cores = cores;
         this.memslices = memslices;
     }
 
     public RegisterNodeRequest(final byte[] data) {
         assert (data.length == RegisterNodeRequest.BYTE_LEN);
-        this.cores = Utils.bytesToLong(data, 0);
-        this.memslices = Utils.bytesToLong(data, Long.BYTES);
+        this.id = Utils.bytesToLong(data, 0);
+        this.cores = Utils.bytesToLong(data, Long.BYTES);
+        this.memslices = Utils.bytesToLong(data, Long.BYTES * 2);
+        
     }
 
     public byte[] toBytes() {
         final byte[] buff = new byte[RegisterNodeRequest.BYTE_LEN];
-        Utils.longToBytes(this.cores, buff, 0);
-        Utils.longToBytes(this.memslices, buff, Long.BYTES);
+        Utils.longToBytes(this.id, buff, 0);
+        Utils.longToBytes(this.cores, buff, Long.BYTES);
+        Utils.longToBytes(this.memslices, buff, Long.BYTES * 2);
 	return buff;
     }
 
     @Override
     public String toString() {
-        return "RegisterNodeRequest(cores=" + this.cores + ", memslices=" + this.memslices + ")";
+        return "RegisterNodeRequest(id=" + this.id + ", cores=" + this.cores + ", memslices=" + this.memslices + ")";
     }
 }

--- a/src/main/java/com/vmware/bespin/scheduler/rpc/RegisterNodeResponse.java
+++ b/src/main/java/com/vmware/bespin/scheduler/rpc/RegisterNodeResponse.java
@@ -5,25 +5,23 @@
 
 package com.vmware.bespin.scheduler.rpc;
 
-import com.vmware.bespin.rpc.Utils;
-
 public class RegisterNodeResponse {
-    public static final int BYTE_LEN = Long.BYTES;
+     public static final int BYTE_LEN = 1;
 
-    final long nodeId;
+    final byte nodeCreated;
 
-    public RegisterNodeResponse(final long nodeId) {
-        this.nodeId = nodeId;
+    public RegisterNodeResponse(final boolean nodeCreated) {
+        this.nodeCreated = (byte) (nodeCreated ? 1 : 0);
     }
 
     public RegisterNodeResponse(final byte[] data) {
         assert (data.length == RegisterNodeResponse.BYTE_LEN);
-        this.nodeId = Utils.bytesToLong(data, 0);
+        this.nodeCreated = data[0];
     }
 
     public byte[] toBytes() {
         final byte[] buff = new byte[RegisterNodeResponse.BYTE_LEN];
-        Utils.longToBytes(this.nodeId, buff, 0);
+        buff[0] = this.nodeCreated;
         return buff;
     }
 }

--- a/src/test/java/com/vmware/bespin/rpc/TestTCPClientServer.java
+++ b/src/test/java/com/vmware/bespin/rpc/TestTCPClientServer.java
@@ -29,8 +29,8 @@ public class TestTCPClientServer {
  
     @Test
     public void testTCPClientServer() throws IOException {
-        final RPCServer<Integer> rpcServer = new TCPServer<Integer>("LOCALHOST", 10110);
-        final RPCClient rpcClient = new TCPClient(InetAddress.getByName("LOCALHOST"), 10110);
+        final RPCServer<Integer> rpcServer = new TCPServer<Integer>("LOCALHOST", 10210);
+        final RPCClient rpcClient = new TCPClient(InetAddress.getByName("LOCALHOST"), 10210);
 
         final Runnable serverRunner =
         () -> {

--- a/src/test/java/com/vmware/bespin/scheduler/rpc/TestSerialization.java
+++ b/src/test/java/com/vmware/bespin/scheduler/rpc/TestSerialization.java
@@ -51,21 +51,28 @@ public class TestSerialization {
 
     @Test
     public void testRegisterNodeRequest() {
-        RegisterNodeRequest req = new RegisterNodeRequest((byte) 3, (byte) 4);
+        RegisterNodeRequest req = new RegisterNodeRequest(2, (byte) 3, (byte) 4);
         byte[] b = req.toBytes();
         assert(b.length == RegisterNodeRequest.BYTE_LEN);
         RegisterNodeRequest req2 = new RegisterNodeRequest(b);
+        assert(req2.id == req.id);
         assert(req2.cores == req.cores);
         assert(req2.memslices == req.memslices);
     }
 
     @Test
     public void testRegisterNodeResponse() {
-        RegisterNodeResponse res = new RegisterNodeResponse(35);
+        RegisterNodeResponse res = new RegisterNodeResponse(true);
         byte[] b = res.toBytes();
         assert(b.length == RegisterNodeResponse.BYTE_LEN);
         RegisterNodeResponse res2 = new RegisterNodeResponse(b);
-        assert(res2.nodeId == res.nodeId);
+        assert(res2.nodeCreated == res.nodeCreated);
+
+        res = new RegisterNodeResponse(false);
+        b = res.toBytes();
+        assert(b.length == RegisterNodeResponse.BYTE_LEN);
+        res2 = new RegisterNodeResponse(b);
+        assert(res2.nodeCreated == res.nodeCreated);
     }
 
     @Test


### PR DESCRIPTION
Rather than the nrk-dcm-scheduler choosing the node id, the node id is supplied by the controller.